### PR TITLE
AbstractPirateNPC behavior update

### DIFF
--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/navy/AbstractNavyNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/navy/AbstractNavyNPC.java
@@ -5,7 +5,6 @@ import net.minecraft.util.TimeUtil;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.NeutralMob;
 import net.minecraft.world.entity.PathfinderMob;
@@ -13,18 +12,14 @@ import net.minecraft.world.entity.ai.goal.*;
 import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
 import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
 import net.minecraft.world.entity.ai.goal.target.ResetUniversalAngerTargetGoal;
-import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minemod.onepiecemod.entity.npcs.pirate.PirateNPC;
-import net.minemod.onepiecemod.item.ModItems;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class AbstractNavyNPC extends PathfinderMob implements NeutralMob {
 
@@ -40,8 +35,6 @@ public abstract class AbstractNavyNPC extends PathfinderMob implements NeutralMo
     public AbstractNavyNPC(EntityType<? extends PathfinderMob> type, Level pLevel) {
         super(type, pLevel);
     }
-
-    //TODO: Register new goals
 
     /**
      * registerGoals()
@@ -65,8 +58,6 @@ public abstract class AbstractNavyNPC extends PathfinderMob implements NeutralMo
 
         // Makes NavyNPCs attack PirateNPCs in its vicinity (if "persistentAngerTarget" isn't another entity)
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, PirateNPC.class, 10, true, false, null));
-
-        // Might want to set the last boolean value to "false" (if that will cause issues with aggro state?)
         this.targetSelector.addGoal(3, new ResetUniversalAngerTargetGoal<>(this, false));
     }
 
@@ -123,9 +114,9 @@ public abstract class AbstractNavyNPC extends PathfinderMob implements NeutralMo
     }
 
     /**
-     * Handles player interactions. Allows an aggressive NPC to be "bribed" with an Emerald,
+     * Handles player interactions. Allows an aggressive NavyNPC to be "bribed" with an Emerald,
      * resetting its anger and clearing its current targeting priorities.
-     * - Eventually "bribe" mechanic will be abstracted.
+     * - Eventually "bribe" mechanic will be abstracted to AbstractNPC.
      */
     @Override
     public InteractionResult mobInteract(Player player, InteractionHand hand) {

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/navy/NavyNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/navy/NavyNPC.java
@@ -52,7 +52,6 @@ public class NavyNPC extends AbstractNavyNPC {
         return this.entityData.get(VARIANT);
     }
 
-
     public NavyVariant getVariant()
     {
         return NavyVariant.byId(this.entityData.get(VARIANT));

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/pirate/AbstractPirateNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/pirate/AbstractPirateNPC.java
@@ -17,6 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minemod.onepiecemod.entity.npcs.navy.NavyNPC;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/pirate/AbstractPirateNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/pirate/AbstractPirateNPC.java
@@ -1,28 +1,39 @@
 package net.minemod.onepiecemod.entity.npcs.pirate;
 
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.util.TimeUtil;
+import net.minecraft.util.valueproviders.UniformInt;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.NeutralMob;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.*;
 import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
 import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import net.minecraft.world.entity.ai.goal.target.ResetUniversalAngerTargetGoal;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minemod.onepiecemod.entity.npcs.navy.NavyNPC;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.UUID;
 
-public class AbstractPirateNPC extends PathfinderMob {
+public class AbstractPirateNPC extends PathfinderMob implements NeutralMob {
 
-    private static final AtomicBoolean playerAggroEnabled = new AtomicBoolean(false);
+    /** The remaining time (in ticks) that this NPC will stay angry at its target. */
+    private int remainingPersistentAngerTime;
+
+    /** The UUID of the player or entity that this NPC is currently angry at. */
+    private UUID persistentAngerTarget;
+
+    /** Defines the range of time (20 to 39 seconds) that anger will persist when triggered. */
+    private static final UniformInt PERSISTENT_ANGER_TIME = TimeUtil.rangeOfSeconds(20,39);
 
     public AbstractPirateNPC(EntityType<? extends PathfinderMob> type, Level pLevel) {
         super(type, pLevel);
     }
-
-    //TODO: Register new goals
 
     /**
      * registerGoals()
@@ -42,7 +53,11 @@ public class AbstractPirateNPC extends PathfinderMob {
 
         // Targeting logic
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this).setAlertOthers()); // Retaliates when attacked
+
+        // Makes PirateNPCs attack NavyNPCs in its vicinity (if "persistentAngerTarget" isn't another entity)
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, NavyNPC.class, 10, true, false, null));
+        this.targetSelector.addGoal(3, new ResetUniversalAngerTargetGoal<>(this, false));
+
     }
     
     /**
@@ -56,15 +71,91 @@ public class AbstractPirateNPC extends PathfinderMob {
         return true;
     }
 
+    @Override
+    public int getRemainingPersistentAngerTime() {return this.remainingPersistentAngerTime;
+    }
 
     @Override
-    protected void actuallyHurt(@NotNull ServerLevel level, DamageSource source, float amount) {
-        if (source.getEntity() instanceof Player) {
-            if (playerAggroEnabled.compareAndSet(false, true)) {
-                this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, Player.class, true));
+    public void setRemainingPersistentAngerTime(int pRemainingPersistentAngerTime) {
+        this.remainingPersistentAngerTime = pRemainingPersistentAngerTime;
+    }
+
+    @Override
+    @Nullable
+    public UUID getPersistentAngerTarget() {
+        return this.persistentAngerTarget;
+    }
+
+    @Override
+    public void setPersistentAngerTarget(@Nullable UUID pPersistentAngerTarget) {
+        this.persistentAngerTarget = pPersistentAngerTarget;
+    }
+
+    /**
+     * Starts the persistent anger timer by picking a random duration within the defined range.
+     */
+    @Override
+    public void startPersistentAngerTimer() {
+        this.setRemainingPersistentAngerTime(PERSISTENT_ANGER_TIME.sample(this.random));
+    }
+
+    /**
+     * Handles server-side AI steps. Updates the persistent anger timers for the NeutralMob mechanics.
+     */
+    @Override
+    protected void customServerAiStep(ServerLevel pLevel) {
+        // Access pLevel directly
+        this.updatePersistentAnger(pLevel, true);
+
+        // Pass parameter to super method
+        super.customServerAiStep(pLevel);
+    }
+
+    /**
+     * Handles player interactions. Allows an aggressive PirateNPC to be "bribed" with a Diamond,
+     * resetting its anger and clearing its current targeting priorities.
+     * - Eventually "bribe" mechanic will be abstracted to AbstractNPC.
+     */
+    @Override
+    public InteractionResult mobInteract(Player player, InteractionHand hand) {
+        ItemStack itemStack = player.getItemInHand(hand);
+
+        // Ensure execution happens strictly on the server side to manipulate AI goals safely
+        if (!this.level().isClientSide() && this.level() instanceof ServerLevel serverLevel) {
+
+            // If the NPC is hostile to this specific player and the player holds a Diamond
+            if (this.isAngryAt(player, serverLevel) && itemStack.is(Items.DIAMOND)) {
+
+                // Consume 1 diamond unless the player is in Creative Mode
+                if (!player.getAbilities().instabuild) {
+                    itemStack.shrink(1);
+                }
+
+                // 1. Reset standard NeutralMob anger state
+                this.stopBeingAngry();
+
+                // 2. Clear instant combat memories and combat targets
+                this.setTarget(null);
+                this.lastHurtByPlayer = null;
+                this.setLastHurtByMob(null);
+
+                // 3. Force active attack/navigation tasks to instantly drop the player
+                this.targetSelector.getAvailableGoals().forEach(wrappedGoal -> {
+                    if (wrappedGoal.isRunning()) {
+                        wrappedGoal.stop();
+                    }
+                });
+                this.goalSelector.getAvailableGoals().forEach(wrappedGoal -> {
+                    if (wrappedGoal.isRunning()) {
+                        wrappedGoal.stop();
+                    }
+                });
+
+                return InteractionResult.SUCCESS;
             }
         }
-        super.actuallyHurt(level, source, amount);
+        return super.mobInteract(player, hand);
     }
+
 
 }

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/pirate/PirateNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/pirate/PirateNPC.java
@@ -4,11 +4,14 @@ import net.minecraft.Util;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.DifficultyInstance;
-import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.storage.ValueInput;
@@ -31,7 +34,7 @@ public class PirateNPC extends AbstractPirateNPC {
      * @return custom attributes for the NPC that extends AbstractNPC
      */
     public static AttributeSupplier.Builder createAttributes() {
-        return Monster.createMobAttributes()
+        return PathfinderMob.createMobAttributes()
                 .add(Attributes.MAX_HEALTH, 2.0D)       // Default is 20 HP. (Set to 2 HP for testing)
                 .add(Attributes.MOVEMENT_SPEED, 0.25D) // Test walking speed
                 .add(Attributes.FOLLOW_RANGE, 16.0D)    // Distance NPCs will track down its target
@@ -49,7 +52,8 @@ public class PirateNPC extends AbstractPirateNPC {
         return this.entityData.get(VARIANT);
     }
 
-    public PirateVariant getVariant() {
+    public PirateVariant getVariant()
+    {
         return PirateVariant.byId(this.entityData.get(VARIANT));
     }
 
@@ -57,16 +61,29 @@ public class PirateNPC extends AbstractPirateNPC {
         this.entityData.set(VARIANT, variant.getId());
     }
 
+    /**
+     * Saves custom data to the NBT tag compound, including entity variants
+     * and active NeutralMob persistent anger states.
+     */
     @Override
     protected void addAdditionalSaveData(ValueOutput pOutput) {
         super.addAdditionalSaveData(pOutput);
         pOutput.putInt("Variant", this.getTypeVariant());
+        this.addPersistentAngerSaveData(pOutput);
     }
 
+    /**
+     * Reads custom data from the saved NBT tag compound to restore variants
+     * and persistent anger states upon entity load.
+     */
     @Override
     protected void readAdditionalSaveData(ValueInput pInput) {
         super.readAdditionalSaveData(pInput);
         pInput.getInt("Variant").ifPresent(value -> this.entityData.set(VARIANT, value));
+
+        if(this.level() instanceof ServerLevel serverLevel) {
+            this.readPersistentAngerSaveData(serverLevel, pInput);
+        }
     }
 
     @Override


### PR DESCRIPTION
Changelog:

**Added Feature**

- Feature: "Bribe" an aggressive PirateNPC to make them neutral. 

- How it works: Right Click on the PirateNPC with a diamond to make them neutral (no longer will target the player)

- Reason: I want the PirateNPCs to be neutral by default, and only aggressive when attacked. However, I wanted there to be a way for players (or eventually other NPCs) to "bribe" their way out of danger when chased by a group of PirateNPCs.


This functionality mirrors the Functionality of AbstractNavyNPC, and will be changed in a future Issue/Branch.