### PR TITLE
NPC Inventory

### DIFF
--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/AbstractNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/AbstractNPC.java
@@ -1,10 +1,25 @@
 package net.minemod.onepiecemod.entity.npcs;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.ai.goal.*;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import net.minecraftforge.event.entity.living.MobSpawnEvent;
+
+import javax.annotation.Nullable;
 
 /**
  * This Class is the Parent Class to all NPCs.
@@ -13,9 +28,14 @@ import net.minecraft.world.level.Level;
  */
 public abstract class AbstractNPC extends PathfinderMob {
 
+    /** Variables */
+    protected static final int DEFAULT_INVENTORY_SIZE = 9;
+    protected SimpleContainer inventory;
+
     /** Constructor */
     public AbstractNPC(EntityType<? extends PathfinderMob> type, Level pLevel) {
         super(type, pLevel);
+        this.inventory = new SimpleContainer(this.getInventorySize());
     }
 
     /**
@@ -34,6 +54,76 @@ public abstract class AbstractNPC extends PathfinderMob {
 
         this.goalSelector.addGoal(3, new LookAtPlayerGoal(this, Player.class, 8.0F)); // Looks at nearby players
         this.goalSelector.addGoal(4, new RandomLookAroundGoal(this)); // Idle head movement
+    }
+
+    /** Inventory Methods
+     * -
+     * Defines the inventory capacity for this NPC.
+     * Override this in child classes (e.g., AbstractNavyNPC or PirateMerchantNPC)
+     * to give specific mobs larger or smaller inventories.
+     */
+    public int getInventorySize() {
+        return DEFAULT_INVENTORY_SIZE;
+    }
+
+    /**
+     * Getter for the NPC's inventory container.
+     * Useful for Pickpocketable, Tradeable, or Bribable interactions.
+     */
+    public SimpleContainer getInventory() {
+        return this.inventory;
+    }
+
+    /**
+     * NBT Persistence - Saving of NPC Inventories
+     */
+    @Override
+    protected void addAdditionalSaveData(ValueOutput pOutput) {
+        super.addAdditionalSaveData(pOutput);
+        // Let pOutput create/handle the typed list safely
+        this.inventory.storeAsItemList(pOutput.list("Items", ItemStack.CODEC));
+    }
+
+    /**
+     * NBT Persistence - Loading of NPC Inventories
+     */
+    @Override
+    protected void readAdditionalSaveData(ValueInput input) {
+        super.readAdditionalSaveData(input);
+
+        // Use .ifPresent(...) because input.list(...) returns Optional
+        input.list("Items", ItemStack.CODEC).ifPresent(this.inventory::fromItemList);
+    }
+
+    @Override
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource source, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, source, recentlyHit);
+
+        if (this.inventory != null) {
+            this.inventory.removeAllItems().forEach(stack -> this.spawnAtLocation(level, stack));
+        }
+    }
+
+    /**
+     * Called when the mob is spawned in the world (naturally, via spawn egg, or command).
+     */
+    @Override
+    public @Nullable SpawnGroupData finalizeSpawn(ServerLevelAccessor pLevel, DifficultyInstance pDifficulty, EntitySpawnReason pSpawnReason, @Nullable SpawnGroupData pSpawnGroupData) {
+        SpawnGroupData data = super.finalizeSpawn(pLevel, pDifficulty, pSpawnReason, pSpawnGroupData);
+
+        // Only populate items if this is a fresh spawn (not loading from world save NBT)
+        this.populateDefaultInventory(pLevel.getRandom());
+
+        return data;
+    }
+
+    /**
+     * Override this in child classes (e.g., PirateNPC, NavyNPC) to define default inventory items.
+     */
+    protected void populateDefaultInventory(RandomSource random) {
+        // Default base items for ALL NPCs (optional)
+        // Example:
+        this.getInventory().addItem(new ItemStack(Items.BREAD, 2));
     }
 
     /**

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/AbstractNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/AbstractNPC.java
@@ -95,6 +95,11 @@ public abstract class AbstractNPC extends PathfinderMob {
         input.list("Items", ItemStack.CODEC).ifPresent(this.inventory::fromItemList);
     }
 
+    /**
+     * dropCustomDeathLoot()
+     * - This method defines what drops when the NPC dies. By default, entire inventory will drop.
+     * - (Eventually, can have certain items that will drop 100% and some that drop at lower chances.)
+     * */
     @Override
     protected void dropCustomDeathLoot(ServerLevel level, DamageSource source, boolean recentlyHit) {
         super.dropCustomDeathLoot(level, source, recentlyHit);
@@ -109,26 +114,23 @@ public abstract class AbstractNPC extends PathfinderMob {
      */
     @Override
     public @Nullable SpawnGroupData finalizeSpawn(ServerLevelAccessor pLevel, DifficultyInstance pDifficulty, EntitySpawnReason pSpawnReason, @Nullable SpawnGroupData pSpawnGroupData) {
-        SpawnGroupData data = super.finalizeSpawn(pLevel, pDifficulty, pSpawnReason, pSpawnGroupData);
-
         // Only populate items if this is a fresh spawn (not loading from world save NBT)
         this.populateDefaultInventory(pLevel.getRandom());
 
-        return data;
+        return super.finalizeSpawn(pLevel, pDifficulty, pSpawnReason, pSpawnGroupData);
     }
 
     /**
      * Override this in child classes (e.g., PirateNPC, NavyNPC) to define default inventory items.
      */
     protected void populateDefaultInventory(RandomSource random) {
-        // Default base items for ALL NPCs (optional)
-        // Example:
-        this.getInventory().addItem(new ItemStack(Items.BREAD, 2));
+        // Left blank, so Child NPC classes can Override and implement their own inventories.
+        // Example: this.getInventory().addItem(new ItemStack(Items.BREAD, 2));
     }
 
     /**
      * isPushable()
-     * - Abstract NPC will move when nudged by the Player.
+     * - All NPCs have collision with the Player (will move when nudged by the Player).
      */
     @Override
     public boolean isPushable() {

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/navy/NavyNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/navy/NavyNPC.java
@@ -14,7 +14,6 @@ import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.storage.ValueInput;
@@ -58,8 +57,8 @@ public class NavyNPC extends AbstractNavyNPC {
      * - getTypeVariant()
      * - getVariant()
      * - setVariant()
-     * - addAdditionalSaveData()
-     * - readAdditionalSaveData()
+     * - addAdditionalSaveData() - Saves custom Variant data to the NBT tag compound
+     * - readAdditionalSaveData() - Reads custom Variant data from the NBT tag compound
      * @param builder The data builder used to register network-synced entity parameters.
      */
     @Override
@@ -81,10 +80,6 @@ public class NavyNPC extends AbstractNavyNPC {
         this.entityData.set(VARIANT, variant.getId());
     }
 
-    /**
-     * Saves custom data to the NBT tag compound, including entity variants
-     * and active NeutralMob persistent anger states.
-     */
     @Override
     protected void addAdditionalSaveData(ValueOutput pOutput) {
         super.addAdditionalSaveData(pOutput);
@@ -92,10 +87,6 @@ public class NavyNPC extends AbstractNavyNPC {
         this.addPersistentAngerSaveData(pOutput);
     }
 
-    /**
-     * Reads custom data from the saved NBT tag compound to restore variants
-     * and persistent anger states upon entity load.
-     */
     @Override
     protected void readAdditionalSaveData(ValueInput pInput) {
         super.readAdditionalSaveData(pInput);
@@ -106,13 +97,16 @@ public class NavyNPC extends AbstractNavyNPC {
         }
     }
 
+    /** Override the method definition in AbstractNPC to set the Variant, before calling the super method.  */
     @Override
     public @Nullable SpawnGroupData finalizeSpawn(ServerLevelAccessor pLevel, DifficultyInstance pDifficulty, EntitySpawnReason pSpawnReason, @Nullable SpawnGroupData pSpawnGroupData) {
         NavyVariant variant = Util.getRandom(NavyVariant.values(), this.random);
         this.setVariant(variant);
+
         return super.finalizeSpawn(pLevel, pDifficulty, pSpawnReason, pSpawnGroupData);
     }
 
+    /** Override the method definition in AbstractNPC to make the NPC spawn with 32 Berrys in its inventory. */
     @Override
     protected void populateDefaultInventory(RandomSource random) {
         this.getInventory().addItem(new ItemStack(ModItems.BERRY.get(), 32));

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/navy/NavyNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/navy/NavyNPC.java
@@ -5,6 +5,7 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
@@ -12,11 +13,14 @@ import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.minemod.onepiecemod.client.navy.NavyVariant;
+import net.minemod.onepiecemod.item.ModItems;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -50,7 +54,6 @@ public class NavyNPC extends AbstractNavyNPC {
 
     /**
      * These methods define the "Variant" of the Navy NPC that is spawned.
-     * - (TODO: Should eventually be abstracted out to AbstractNavyNPC...)
      * - defineSynchedData()
      * - getTypeVariant()
      * - getVariant()
@@ -108,5 +111,10 @@ public class NavyNPC extends AbstractNavyNPC {
         NavyVariant variant = Util.getRandom(NavyVariant.values(), this.random);
         this.setVariant(variant);
         return super.finalizeSpawn(pLevel, pDifficulty, pSpawnReason, pSpawnGroupData);
+    }
+
+    @Override
+    protected void populateDefaultInventory(RandomSource random) {
+        this.getInventory().addItem(new ItemStack(ModItems.BERRY.get(), 32));
     }
 }

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/pirate/PirateNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/pirate/PirateNPC.java
@@ -54,8 +54,8 @@ public class PirateNPC extends AbstractPirateNPC {
      * - getTypeVariant()
      * - getVariant()
      * - setVariant()
-     * - addAdditionalSaveData()
-     * - readAdditionalSaveData()
+     * - addAdditionalSaveData() - Saves custom Variant data to the NBT tag compound
+     * - readAdditionalSaveData() - Reads custom Variant data from the NBT tag compound
      * @param builder The data builder used to register network-synced entity parameters.
      */
     @Override
@@ -77,10 +77,6 @@ public class PirateNPC extends AbstractPirateNPC {
         this.entityData.set(VARIANT, variant.getId());
     }
 
-    /**
-     * Saves custom data to the NBT tag compound, including entity variants
-     * and active NeutralMob persistent anger states.
-     */
     @Override
     protected void addAdditionalSaveData(ValueOutput pOutput) {
         super.addAdditionalSaveData(pOutput);
@@ -88,10 +84,6 @@ public class PirateNPC extends AbstractPirateNPC {
         this.addPersistentAngerSaveData(pOutput);
     }
 
-    /**
-     * Reads custom data from the saved NBT tag compound to restore variants
-     * and persistent anger states upon entity load.
-     */
     @Override
     protected void readAdditionalSaveData(ValueInput pInput) {
         super.readAdditionalSaveData(pInput);
@@ -102,6 +94,7 @@ public class PirateNPC extends AbstractPirateNPC {
         }
     }
 
+    /** Override the method definition in AbstractNPC to set the Variant, before calling the super method.  */
     @Override
     public @Nullable SpawnGroupData finalizeSpawn(ServerLevelAccessor pLevel, DifficultyInstance pDifficulty, EntitySpawnReason pSpawnReason, @Nullable SpawnGroupData pSpawnGroupData) {
         PirateVariant variant = Util.getRandom(PirateVariant.values(), this.random);


### PR DESCRIPTION
All NPCs should have an Inventory of some sort. Depending on the Type of NPC, Inventory behavior might need to be customized down the line.

Child classes can override Inventory Size, and populateDefaultInventory() to choose what starts in an NPCs inventory.

- Still need to Document code.
- Might get rid of Bread spawning as default in all NPCs inventorys. Just was using that to test.