### PR TITLE
Add Pickpocket functionality to NavyNPCs

### DIFF
--- a/src/main/java/net/minemod/onepiecemod/entity/interfaces/Pickpocketable.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/interfaces/Pickpocketable.java
@@ -40,13 +40,14 @@ public interface Pickpocketable {
 
     /** Base success chance between 0.0 (0%) and 1.0 (100%). Default is 0.5 (50%). */
     default float getPickpocketChance() {
-        return 0.5f;
+        return 1.0f;
     }
 
-    /** Requires the player to be crouching/sneaking to initiate a pickpocket. Default is true. */
+    /** Requires the player to be crouching/sneaking to initiate a pickpocket. Default is true.
     default boolean requiresSneaking() {
         return true;
     }
+    */
 
     default void onPickpocketSuccess(Player player, PathfinderMob mob) {
         // Reset strike state on successful pickpocket
@@ -126,20 +127,28 @@ public interface Pickpocketable {
     }
 
     default InteractionResult processPickpocket(PathfinderMob mob, Player player, InteractionHand hand) {
-        // Check if player is sneaking, and has an empty hand.
-
         // Check if NPC is pickpocketable (call isPickpocketable())
             // Fail Logic / Lockout error message
 
         // Skill Check (Some kind of Quick Time Event)
-            skillCheck();
+            //  skillCheck();
 
         // If skill check succeeds:
-            onPickpocketSuccess(player, mob);
+            //  onPickpocketSuccess(player, mob);
         // Else, skill check fails:
-            onPickpocketFailed(player, mob);
+            //  onPickpocketFailed(player, mob);
 
-        return null;
+        /** TODO: PICKPOCKET CHANCE TEMPORARILY SET TO 100% */
+        if (!mob.level().isClientSide()) {
+            if (mob.getRandom().nextFloat() <= getPickpocketChance()) {
+                onPickpocketSuccess(player, mob);
+            } else {
+                // Roll failed -> trigger anger & strikes
+                onPickpocketFailed(player, mob);
+            }
+        }
+
+        return InteractionResult.SUCCESS;
     }
 
     default void skillCheck() {

--- a/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/navy/AbstractNavyNPC.java
+++ b/src/main/java/net/minemod/onepiecemod/entity/npcs/neutral/navy/AbstractNavyNPC.java
@@ -18,16 +18,18 @@ import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minemod.onepiecemod.datagen.ModLootProvider;
 import net.minemod.onepiecemod.entity.interfaces.Bribable;
+import net.minemod.onepiecemod.entity.interfaces.Pickpocketable;
 import net.minemod.onepiecemod.entity.npcs.neutral.AbstractNeutralNPC;
 import net.minemod.onepiecemod.entity.npcs.neutral.pirate.PirateNPC;
 
-public abstract class AbstractNavyNPC extends AbstractNeutralNPC implements Bribable {
+public abstract class AbstractNavyNPC extends AbstractNeutralNPC implements Bribable, Pickpocketable {
 
     /** Variables */
     private final int DEFAULT_NAVY_BRIBE_COST = 5;
     private final float DEFAULT_NAVY_BRIBE_CHANCE = 0.5f;
 
     private BribeState bribeState = BribeState.CAN_BRIBE;
+    private PickpocketState pickpocketState = PickpocketState.CAN_PICKPOCKET;
 
     /** Constructor */
     public AbstractNavyNPC(EntityType<? extends PathfinderMob> type, Level pLevel) {
@@ -101,6 +103,16 @@ public abstract class AbstractNavyNPC extends AbstractNeutralNPC implements Brib
         this.bribeState = state;
     }
 
+
+    @Override
+    public PickpocketState getPickpocketState(Player player) {
+        return this.pickpocketState;
+    }
+
+    @Override
+    public void setPickpocketState(PickpocketState state) {
+        this.pickpocketState = state;
+    }
     /**
      * Saves custom data to the NBT tag compound, including entity variants
      * and active NeutralMob persistent anger states.
@@ -129,14 +141,20 @@ public abstract class AbstractNavyNPC extends AbstractNeutralNPC implements Brib
     @Override
     public InteractionResult mobInteract(Player player, InteractionHand hand) {
         // 1. Process Bribe attempt
-        if (this.getBribeState(player) != BribeState.FAILED_PERMANENT) {
+        if ((this.getBribeState(player) != BribeState.FAILED_PERMANENT) && player.getItemInHand(hand).is(this.getBribeItem())) {
             InteractionResult bribeResult = this.processBribe(this, player, hand);
             if (bribeResult.consumesAction()) {
                 return bribeResult;
             }
         }
 
-        // 2. Add future interactions here cleanly (e.g. Trading, Pickpocketing)
+        // 2. Process Pickpocket attempt
+        if ((this.getPickpocketState(player) != PickpocketState.FAILED_PERMANENT) && player.isCrouching()) {
+            InteractionResult pickpocketResult = this.processPickpocket(this, player, hand);
+
+        }
+
+        // 3. Add future interactions here cleanly (e.g. Trading, Pickpocketing)
 
         return super.mobInteract(player, hand);
     }


### PR DESCRIPTION
When sneaking (Holding "Shift" key) and right clicking on a NavyNPC, you can look into their inventory, and take/deposit items.